### PR TITLE
Add dependencies, cleanup readme and add installation on macos via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,52 +12,80 @@ To use Salamandra you nee to have a SDR (Software Define Radio) device. It can b
 
 Salamandra needs the rtl_power software installed in your computer. To install it you can do:
 
-- On MacOS: 
+### On MacOS
 
-    sudo port install rtl-sdr
+Using [macports](https://www.macports.org/install.php)):
 
-If you don't have ports in your MAC, see [port installation](https://www.macports.org/install.php)
+```
+sudo port install rtl-sdr
+pip install pygame
+```
 
-- On Linux: 
+Using [homebrew](https://brew.sh/)):
 
-    apt-get install rtl-sdr
+```
+brew install smpeg
+brew install sdl_mixer --with-smpeg
+brew install sdl
+pip install pygame
+```
 
-- On Windows: See http://www.rtl-sdr.com/getting-the-rtl-sdr-to-work-on-windows-10/
+### On Linux
+
+```
+apt-get install rtl-sdr
+pip install pygame
+```
+
+### On Windows
+
+See http://www.rtl-sdr.com/getting-the-rtl-sdr-to-work-on-windows-10/
 
 If rtl_power was installed correctly, you should be able to run this command in any console:
 
-    rtl_test
+```
+rtl_test
+```
 
 And you should see one device detected.
-
 
 # Usage
 
 ## Basic usage for detecting microphones
 
-    ./salamandra.py 
+```
+./salamandra.py
+```
 
 This command will use a default threshold of 10.8, a min freq of 100Mhz, a max freq of 400Mhz and sound. You can change the default values with parameters.
 
 ## Location Mode to find Hidden Microphones
 
-- Run Salamandra with a threshold of 0, starting in the frequency 100MHz and ending in the frequency 200MHz. Search is activated with (-s). And make sounds (-S)
+Run Salamandra with a threshold of 0, starting in the frequency 100MHz and ending in the frequency 200MHz. Search is activated with (`-s`). And make sounds (`-S`)
 
-    ./salamandra.py -t 0 -a 100 -b 200 -s -S
+```
+./salamandra.py -t 0 -a 100 -b 200 -s -S
+```
 
 ## Location Mode from a stored rtl_power file
 
-    ./salamandra.py -t 0 -a 111 -b 113 -s -f stored.csv
+```
+./salamandra.py -t 0 -a 111 -b 113 -s -f stored.csv
+```
 
 To actually create the file with rtl_power, from 111MHz to 114MHz, with 4000Khz step, gain of 25, integration of 1s and capturing for 5min, you can do:
 
-    rtl_power -f 111M:114M:4000Khz -g 25 -i 1 -e 300 stored.csv
+```
+rtl_power -f 111M:114M:4000Khz -g 25 -i 1 -e 300 stored.csv
+```
 
 ## Detection Mode (deprecated now). To detect microphones in one pass.
 
-- Run Salamandra with a threshold of 0, starting in the frequency 100MHz and ending in the frequency 200MHz. Search is activated with (-s). And make sounds (-S)
+Run Salamandra with a threshold (`-t`) of 10.3 and a second threshold (`-F`) of 2, starting in the frequency 100MHz and ending in the frequency 200MHz.
 
-    ./salamandra.py -t 10.3 -a 100 -b 200 -F 2
+```
+./salamandra.py -t 10.3 -a 100 -b 200 -F 2
+```
 
 
 ## Tips
@@ -74,4 +102,3 @@ To actually create the file with rtl_power, from 111MHz to 114MHz, with 4000Khz 
     - Discard the frequencies that do not look like analog audio (Equidistant freqs)
 3. Logs in file
 4. Make the execution of rtl_power in another process in the background
-

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Salamandra needs the rtl_power software installed in your computer. To install i
 
 ### On MacOS
 
-Using [macports](https://www.macports.org/install.php)):
+Using [macports](https://www.macports.org/install.php):
 
 ```
 sudo port install rtl-sdr
 pip install pygame
 ```
 
-Using [homebrew](https://brew.sh/)):
+Using [homebrew](https://brew.sh/):
 
 ```
 brew install smpeg


### PR DESCRIPTION
Hi,

thanks for your awesome work and the talk at the 34c3.

When I first tried to use your software on macos I realised there are some dependencies (`pygame`, `smpeg` to play the mp3 files and `sdl_mixer`) missing to actually get salamandra to work. And since I'm not using ports I added the homebrew part with these dependencies.

While I was working on the readme I also did some other changes (use backticks instead of indention to add code snippets and and align the documentation of `Detection Mode` to the actual command that is used there) to (in my opinion) enhance the readability a bit.

Malte